### PR TITLE
fix: use claude-sonnet-4-6 for zen-architect steps to resolve daily docs timeout

### DIFF
--- a/recipes/docs-regenerate.yaml
+++ b/recipes/docs-regenerate.yaml
@@ -282,6 +282,9 @@ steps:
   - id: "regenerate-docs"
     agent: "foundation:zen-architect"
     mode: "ARCHITECT"
+    provider_preferences:
+      - provider: anthropic
+        model: claude-sonnet-4-6
     prompt: |
       Perform SURGICAL documentation updates. You MUST preserve existing content that doesn't need changes.
 
@@ -348,6 +351,9 @@ steps:
   - id: "evidence-validation"
     agent: "foundation:zen-architect"
     mode: "REVIEW"
+    provider_preferences:
+      - provider: anthropic
+        model: claude-sonnet-4-6
     prompt: |
       You are a SKEPTICAL EVIDENCE REVIEWER. Your job is to verify that every
       factual claim in the regenerated docs is grounded in actual source code.


### PR DESCRIPTION
## Problem

The `Daily Docs Regeneration` GitHub Actions workflow has been failing since **March 25, 2026**.

**Root cause:** The `zen-architect` agent steps in `recipes/docs-regenerate.yaml` were defaulting to `claude-opus-4-6` (heavy/slow model). When 8 sections went stale simultaneously, the recipe timed out at the 1200s limit before completing.

## Fix

Added `provider_preferences: anthropic/claude-sonnet-4-6` to two `foundation:zen-architect` agent steps:

1. **`regenerate-docs`** — the main surgical documentation regeneration pass
2. **`evidence-validation`** — the evidence review pass

Sonnet is significantly faster than Opus for these structured regeneration tasks while maintaining sufficient quality for documentation generation.

## Validation

Recipe validation passed (`status: valid`) before this PR was opened.

---

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)