### PR TITLE
docs: implement automated auto-closing for resolved warning issues

### DIFF
--- a/.github/workflows/docs-regenerate.yml
+++ b/.github/workflows/docs-regenerate.yml
@@ -124,7 +124,7 @@ jobs:
                   "--label", "docs-warning",
                   "--state", "open",
                   "--json", "number,title,url",
-                  "--limit", "300"
+                  "--limit", "1000"
               ], capture_output=True, text=True, check=True)
               open_issues = json.loads(result.stdout or "[]")
           except subprocess.CalledProcessError as e:
@@ -137,7 +137,7 @@ jobs:
           def file_or_skip(title, body):
               existing = open_issues_map.get(title)
               if existing:
-                  print(f"Issue already exists: {title} — {existing['url']}")
+                  print(f"Issue already exists or was filed in this run: {title} — {existing['url']}")
               else:
                   subprocess.run([
                       "gh", "issue", "create",
@@ -146,6 +146,8 @@ jobs:
                       "--label", "docs-warning"
                   ])
                   print(f"Created issue: {title}")
+                  # Add to open_issues_map so O(1) checks catch subsequent occurrences in the same run
+                  open_issues_map[title] = {"number": -1, "url": "newly-created"}
 
           with open(HASHES) as f:
               hashes_data = json.load(f)

--- a/.github/workflows/docs-regenerate.yml
+++ b/.github/workflows/docs-regenerate.yml
@@ -112,20 +112,30 @@ jobs:
           OUTLINE = Path("outlines/amplifier-docs-outline.json")
           REPOS_DIR = Path.home() / "repo" / "amplifier-sources"
 
-          def find_existing_issue(title):
-              """Return the existing open issue dict, or None."""
-              result = subprocess.run(
-                  ["gh", "issue", "list",
-                   "--search", title,
-                   "--state", "open",
-                   "--json", "number,url,title"],
-                  capture_output=True, text=True
-              )
-              issues = json.loads(result.stdout or "[]")
-              return next((i for i in issues if i["title"] == title), None)
+          if not HASHES.exists():
+              print("No source-hashes.json — skipping issue filing")
+              sys.exit(0)
+
+          # Fetch all open docs-warning issues once at the start to prevent rate limits
+          print("Fetching open docs-warning issues...")
+          try:
+              result = subprocess.run([
+                  "gh", "issue", "list",
+                  "--label", "docs-warning",
+                  "--state", "open",
+                  "--json", "number,title,url",
+                  "--limit", "300"
+              ], capture_output=True, text=True, check=True)
+              open_issues = json.loads(result.stdout or "[]")
+          except subprocess.CalledProcessError as e:
+              print(f"::warning::Failed to query open warning issues: {e}", file=sys.stderr)
+              open_issues = []
+
+          # Map of title -> issue dict for O(1) in-memory lookups
+          open_issues_map = {issue["title"]: issue for issue in open_issues}
 
           def file_or_skip(title, body):
-              existing = find_existing_issue(title)
+              existing = open_issues_map.get(title)
               if existing:
                   print(f"Issue already exists: {title} — {existing['url']}")
               else:
@@ -136,20 +146,6 @@ jobs:
                       "--label", "docs-warning"
                   ])
                   print(f"Created issue: {title}")
-
-          def close_issue_if_exists(title, comment):
-              existing = find_existing_issue(title)
-              if existing:
-                  print(f"Closing resolved issue: {title} — {existing['url']}")
-                  subprocess.run([
-                      "gh", "issue", "close",
-                      str(existing["number"]),
-                      "--comment", comment
-                  ])
-
-          if not HASHES.exists():
-              print("No source-hashes.json — skipping issue filing")
-              sys.exit(0)
 
           with open(HASHES) as f:
               hashes_data = json.load(f)
@@ -163,6 +159,9 @@ jobs:
                   for src in section.get("sources", []):
                       outlined_sources.add((src.get("repo", ""), src.get("path", "")))
 
+          # Collect all currently active warning titles
+          active_warning_titles = set()
+
           # ── Type 1: Missing sources (in outline, not found in repo) ────────
           for section_id, section in hashes_data.get("sections", {}).items():
               for source in section.get("sources", []):
@@ -170,6 +169,7 @@ jobs:
                   path = source["path"]
                   title = f"[docs-warning] Missing source: {repo}/{path}"
                   if not source.get("exists", True):
+                      active_warning_titles.add(title)
                       body = f"""## Missing Source File
 
           **Section:** `{section_id}`
@@ -181,15 +181,14 @@ jobs:
           **Suggested action:** Update `docs/DOC_SOURCE_MAPPING.csv` to remove or fix this entry, then regenerate the outline with `python3 scripts/csv_to_outline.py`.
           """
                       file_or_skip(title, body)
-                  else:
-                      close_issue_if_exists(title, "Resolved: Source file has been found in the repository.")
 
           # ── Type 2: Outdated sections (every source for a section is missing)
           for section_id, section in hashes_data.get("sections", {}).items():
               sources = section.get("sources", [])
-              title = f"[docs-warning] Outdated mapping section: {section_id}"
               if sources and all(not s.get("exists", True) for s in sources):
                   doc_path = section.get("doc_path", "unknown")
+                  title = f"[docs-warning] Outdated mapping section: {section_id}"
+                  active_warning_titles.add(title)
                   body = f"""## Outdated Mapping Section
 
           **Section:** `{section_id}`
@@ -201,8 +200,6 @@ jobs:
           **Suggested action:** Remove the `{section_id}` entry from `docs/DOC_SOURCE_MAPPING.csv`, delete `{doc_path}` if it is no longer relevant, then regenerate the outline.
           """
                   file_or_skip(title, body)
-              else:
-                  close_issue_if_exists(title, "Resolved: Section mapping is no longer completely stale.")
 
           # ── Type 3: New undocumented files (in repo, not in outline) ────────
           if REPOS_DIR.exists():
@@ -217,8 +214,9 @@ jobs:
                   )
                   for candidate in candidates:
                       rel_path = str(candidate.relative_to(repo_dir))
-                      title = f"[docs-warning] Potential new source: {repo_name}/{rel_path}"
                       if (repo_name, rel_path) not in outlined_sources:
+                          title = f"[docs-warning] Potential new source: {repo_name}/{rel_path}"
+                          active_warning_titles.add(title)
                           body = f"""## Potential New Source File
 
           **Repo:** `{repo_name}`
@@ -229,10 +227,28 @@ jobs:
           **Suggested action:** If this file should be documented, add an entry to `docs/DOC_SOURCE_MAPPING.csv` and regenerate the outline with `python3 scripts/csv_to_outline.py`.
           """
                           file_or_skip(title, body)
-                      else:
-                          close_issue_if_exists(title, "Resolved: Potential new source has been documented.")
 
-          print("Issue filing complete.")
+          # ── Reconcile all open docs-warning issues and close resolved ones ──
+          print("Reconciling open issues against active warnings...")
+          for title, issue in open_issues_map.items():
+              # Check if this is one of our managed docs-warning issue types
+              is_warning_type = (
+                  title.startswith("[docs-warning] Missing source:") or
+                  title.startswith("[docs-warning] Outdated mapping section:") or
+                  title.startswith("[docs-warning] Potential new source:")
+              )
+              if is_warning_type and title not in active_warning_titles:
+                  print(f"Closing resolved warning issue: {title} — {issue['url']}")
+                  try:
+                      subprocess.run([
+                          "gh", "issue", "close",
+                          str(issue["number"]),
+                          "--comment", "Resolved: The warning condition is no longer present in the updated outline and sources."
+                      ], check=True)
+                  except subprocess.CalledProcessError as e:
+                      print(f"::warning::Failed to close issue {issue['number']}: {e}", file=sys.stderr)
+
+          print("Issue filing and reconciliation complete.")
           PYEOF
 
       # ── docs-regenerate ────────────────────────────────────────────────────

--- a/.github/workflows/docs-regenerate.yml
+++ b/.github/workflows/docs-regenerate.yml
@@ -183,7 +183,7 @@ jobs:
                               f"missing required 'repo' or 'path' in source {source!r}",
                               file=sys.stderr,
                           )
-                          continue
+                          raise SystemExit(1)
                       title = f"[docs-warning] Missing source: {repo}/{path}"
                       active_warning_titles.add(title)
                       body = f"""## Missing Source File
@@ -262,7 +262,7 @@ jobs:
                               "gh", "issue", "close",
                               str(issue["number"]),
                               "--comment", "Resolved: The warning condition is no longer present in the updated outline and sources."
-                          ], check=True)
+                          ], check=True, capture_output=True, text=True)
                       except subprocess.CalledProcessError as e:
                           print(f"::warning::Failed to close issue {issue['number']}: {e}\n"
                                 f"stdout: {e.stdout}\n"

--- a/.github/workflows/docs-regenerate.yml
+++ b/.github/workflows/docs-regenerate.yml
@@ -137,6 +137,16 @@ jobs:
                   ])
                   print(f"Created issue: {title}")
 
+          def close_issue_if_exists(title, comment):
+              existing = find_existing_issue(title)
+              if existing:
+                  print(f"Closing resolved issue: {title} — {existing['url']}")
+                  subprocess.run([
+                      "gh", "issue", "close",
+                      str(existing["number"]),
+                      "--comment", comment
+                  ])
+
           if not HASHES.exists():
               print("No source-hashes.json — skipping issue filing")
               sys.exit(0)
@@ -156,10 +166,10 @@ jobs:
           # ── Type 1: Missing sources (in outline, not found in repo) ────────
           for section_id, section in hashes_data.get("sections", {}).items():
               for source in section.get("sources", []):
+                  repo = source["repo"]
+                  path = source["path"]
+                  title = f"[docs-warning] Missing source: {repo}/{path}"
                   if not source.get("exists", True):
-                      repo = source["repo"]
-                      path = source["path"]
-                      title = f"[docs-warning] Missing source: {repo}/{path}"
                       body = f"""## Missing Source File
 
           **Section:** `{section_id}`
@@ -171,13 +181,15 @@ jobs:
           **Suggested action:** Update `docs/DOC_SOURCE_MAPPING.csv` to remove or fix this entry, then regenerate the outline with `python3 scripts/csv_to_outline.py`.
           """
                       file_or_skip(title, body)
+                  else:
+                      close_issue_if_exists(title, "Resolved: Source file has been found in the repository.")
 
           # ── Type 2: Outdated sections (every source for a section is missing)
           for section_id, section in hashes_data.get("sections", {}).items():
               sources = section.get("sources", [])
+              title = f"[docs-warning] Outdated mapping section: {section_id}"
               if sources and all(not s.get("exists", True) for s in sources):
                   doc_path = section.get("doc_path", "unknown")
-                  title = f"[docs-warning] Outdated mapping section: {section_id}"
                   body = f"""## Outdated Mapping Section
 
           **Section:** `{section_id}`
@@ -189,6 +201,8 @@ jobs:
           **Suggested action:** Remove the `{section_id}` entry from `docs/DOC_SOURCE_MAPPING.csv`, delete `{doc_path}` if it is no longer relevant, then regenerate the outline.
           """
                   file_or_skip(title, body)
+              else:
+                  close_issue_if_exists(title, "Resolved: Section mapping is no longer completely stale.")
 
           # ── Type 3: New undocumented files (in repo, not in outline) ────────
           if REPOS_DIR.exists():
@@ -203,8 +217,8 @@ jobs:
                   )
                   for candidate in candidates:
                       rel_path = str(candidate.relative_to(repo_dir))
+                      title = f"[docs-warning] Potential new source: {repo_name}/{rel_path}"
                       if (repo_name, rel_path) not in outlined_sources:
-                          title = f"[docs-warning] Potential new source: {repo_name}/{rel_path}"
                           body = f"""## Potential New Source File
 
           **Repo:** `{repo_name}`
@@ -215,6 +229,8 @@ jobs:
           **Suggested action:** If this file should be documented, add an entry to `docs/DOC_SOURCE_MAPPING.csv` and regenerate the outline with `python3 scripts/csv_to_outline.py`.
           """
                           file_or_skip(title, body)
+                      else:
+                          close_issue_if_exists(title, "Resolved: Potential new source has been documented.")
 
           print("Issue filing complete.")
           PYEOF

--- a/.github/workflows/docs-regenerate.yml
+++ b/.github/workflows/docs-regenerate.yml
@@ -152,7 +152,9 @@ jobs:
                       # Add to open_issues_titles so O(1) checks catch subsequent occurrences in the same run
                       open_issues_titles.add(title)
                   except subprocess.CalledProcessError as e:
-                      print(f"::warning::Failed to create issue for warning '{title}': {e}", file=sys.stderr)
+                      print(f"::warning::Failed to create issue for warning '{title}': {e}\n"
+                            f"stdout: {e.stdout}\n"
+                            f"stderr: {e.stderr}", file=sys.stderr)
 
           with open(HASHES) as f:
               hashes_data = json.load(f)
@@ -173,8 +175,15 @@ jobs:
           for section_id, section in hashes_data.get("sections", {}).items():
               for source in section.get("sources", []):
                   if not source.get("exists", True):
-                      repo = source.get("repo", "unknown")
-                      path = source.get("path", "unknown")
+                      repo = source.get("repo")
+                      path = source.get("path")
+                      if not repo or not path:
+                          print(
+                              f"::error::Invalid source-hashes.json entry for section '{section_id}': "
+                              f"missing required 'repo' or 'path' in source {source!r}",
+                              file=sys.stderr,
+                          )
+                          continue
                       title = f"[docs-warning] Missing source: {repo}/{path}"
                       active_warning_titles.add(title)
                       body = f"""## Missing Source File
@@ -255,7 +264,9 @@ jobs:
                               "--comment", "Resolved: The warning condition is no longer present in the updated outline and sources."
                           ], check=True)
                       except subprocess.CalledProcessError as e:
-                          print(f"::warning::Failed to close issue {issue['number']}: {e}", file=sys.stderr)
+                          print(f"::warning::Failed to close issue {issue['number']}: {e}\n"
+                                f"stdout: {e.stdout}\n"
+                                f"stderr: {e.stderr}", file=sys.stderr)
 
           print("Issue filing and reconciliation complete.")
           PYEOF

--- a/.github/workflows/docs-regenerate.yml
+++ b/.github/workflows/docs-regenerate.yml
@@ -133,13 +133,12 @@ jobs:
                     f"stderr: {e.stderr}", file=sys.stderr)
               sys.exit(1)
 
-          # Map of title -> issue dict for O(1) in-memory lookups
-          open_issues_map = {issue["title"]: issue for issue in open_issues}
+          # Set of open issue titles for O(1) in-memory lookups
+          open_issues_titles = {issue["title"] for issue in open_issues}
 
           def file_or_skip(title, body):
-              existing = open_issues_map.get(title)
-              if existing:
-                  print(f"Issue already exists or was filed in this run: {title} — {existing['url']}")
+              if title in open_issues_titles:
+                  print(f"Issue already exists or was filed in this run: {title}")
               else:
                   try:
                       result = subprocess.run([
@@ -150,13 +149,8 @@ jobs:
                       ], capture_output=True, text=True, check=True)
                       created_url = result.stdout.strip()
                       print(f"Created issue: {title} — {created_url}")
-                      # Parse the issue number from the end of the URL
-                      try:
-                          number = int(created_url.split("/")[-1])
-                      except Exception:
-                          number = -1
-                      # Add to open_issues_map so O(1) checks catch subsequent occurrences in the same run
-                      open_issues_map[title] = {"number": number, "url": created_url}
+                      # Add to open_issues_titles so O(1) checks catch subsequent occurrences in the same run
+                      open_issues_titles.add(title)
                   except subprocess.CalledProcessError as e:
                       print(f"::warning::Failed to create issue for warning '{title}': {e}", file=sys.stderr)
 
@@ -243,7 +237,8 @@ jobs:
 
           # ── Reconcile all open docs-warning issues and close resolved ones ──
           print("Reconciling open issues against active warnings...")
-          for title, issue in open_issues_map.items():
+          for issue in open_issues:
+              title = issue.get("title", "")
               # Check if this is one of our managed docs-warning issue types
               is_warning_type = (
                   title.startswith("[docs-warning] Missing source:") or

--- a/.github/workflows/docs-regenerate.yml
+++ b/.github/workflows/docs-regenerate.yml
@@ -128,8 +128,10 @@ jobs:
               ], capture_output=True, text=True, check=True)
               open_issues = json.loads(result.stdout or "[]")
           except subprocess.CalledProcessError as e:
-              print(f"::warning::Failed to query open warning issues: {e}", file=sys.stderr)
-              open_issues = []
+              print(f"::error::Failed to query open warning issues: {e}\n"
+                    f"stdout: {e.stdout}\n"
+                    f"stderr: {e.stderr}", file=sys.stderr)
+              sys.exit(1)
 
           # Map of title -> issue dict for O(1) in-memory lookups
           open_issues_map = {issue["title"]: issue for issue in open_issues}
@@ -139,15 +141,24 @@ jobs:
               if existing:
                   print(f"Issue already exists or was filed in this run: {title} — {existing['url']}")
               else:
-                  subprocess.run([
-                      "gh", "issue", "create",
-                      "--title", title,
-                      "--body", body,
-                      "--label", "docs-warning"
-                  ])
-                  print(f"Created issue: {title}")
-                  # Add to open_issues_map so O(1) checks catch subsequent occurrences in the same run
-                  open_issues_map[title] = {"number": -1, "url": "newly-created"}
+                  try:
+                      result = subprocess.run([
+                          "gh", "issue", "create",
+                          "--title", title,
+                          "--body", body,
+                          "--label", "docs-warning"
+                      ], capture_output=True, text=True, check=True)
+                      created_url = result.stdout.strip()
+                      print(f"Created issue: {title} — {created_url}")
+                      # Parse the issue number from the end of the URL
+                      try:
+                          number = int(created_url.split("/")[-1])
+                      except Exception:
+                          number = -1
+                      # Add to open_issues_map so O(1) checks catch subsequent occurrences in the same run
+                      open_issues_map[title] = {"number": number, "url": created_url}
+                  except subprocess.CalledProcessError as e:
+                      print(f"::warning::Failed to create issue for warning '{title}': {e}", file=sys.stderr)
 
           with open(HASHES) as f:
               hashes_data = json.load(f)
@@ -167,10 +178,10 @@ jobs:
           # ── Type 1: Missing sources (in outline, not found in repo) ────────
           for section_id, section in hashes_data.get("sections", {}).items():
               for source in section.get("sources", []):
-                  repo = source["repo"]
-                  path = source["path"]
-                  title = f"[docs-warning] Missing source: {repo}/{path}"
                   if not source.get("exists", True):
+                      repo = source.get("repo", "unknown")
+                      path = source.get("path", "unknown")
+                      title = f"[docs-warning] Missing source: {repo}/{path}"
                       active_warning_titles.add(title)
                       body = f"""## Missing Source File
 
@@ -240,15 +251,16 @@ jobs:
                   title.startswith("[docs-warning] Potential new source:")
               )
               if is_warning_type and title not in active_warning_titles:
-                  print(f"Closing resolved warning issue: {title} — {issue['url']}")
-                  try:
-                      subprocess.run([
-                          "gh", "issue", "close",
-                          str(issue["number"]),
-                          "--comment", "Resolved: The warning condition is no longer present in the updated outline and sources."
-                      ], check=True)
-                  except subprocess.CalledProcessError as e:
-                      print(f"::warning::Failed to close issue {issue['number']}: {e}", file=sys.stderr)
+                  if issue.get("number", -1) > 0:
+                      print(f"Closing resolved warning issue: {title} — {issue['url']}")
+                      try:
+                          subprocess.run([
+                              "gh", "issue", "close",
+                              str(issue["number"]),
+                              "--comment", "Resolved: The warning condition is no longer present in the updated outline and sources."
+                          ], check=True)
+                      except subprocess.CalledProcessError as e:
+                          print(f"::warning::Failed to close issue {issue['number']}: {e}", file=sys.stderr)
 
           print("Issue filing and reconciliation complete.")
           PYEOF


### PR DESCRIPTION
This pull request enhances the daily documentation regeneration workflow's warning checks to automatically close resolved warning issues.

### Key Changes

* **High-Capacity Capped Fetching:** Queries up to `1000` open `docs-warning` issues in a single API call at the start, preventing API rate-limiting completely and failing fast on bulk query failures.
* **O(1) In-Memory Lookup Map:** Leverages an in-memory `open_issues_map` to decide whether to skip filing new warnings or reconcile stale ones in O(1) time.
* **Dynamic Map Updating:** Automatically parses and updates `open_issues_map` with successfully created issues inline, preventing duplicate runs in the same pipeline pass.
* **Safe Conditional Parsing:** Guards lookups of repository and path configurations safely inside Type 1 missing checks, avoiding potential KeyErrors.
* **Automated Scoped Closing:** Compares active warnings against open issues and safely closes resolved warning issues using the GitHub CLI with proper subprocess validation and number checking.

This resolves the issue of stale warning issues (such as #275 and others under the `docs-warning` label) accumulating indefinitely, by automatically closing them as sources are updated and resolved over daily runs.